### PR TITLE
fixed item group display name

### DIFF
--- a/src/main/java/com/ianm1647/farmersknives/FarmersKnives.java
+++ b/src/main/java/com/ianm1647/farmersknives/FarmersKnives.java
@@ -27,7 +27,7 @@ public class FarmersKnives implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		Registry.register(Registries.ITEM_GROUP, GROUP, FabricItemGroup.builder()
-				.displayName(Text.literal("itemGroup.farmersknives.group"))
+				.displayName(Text.translatable("itemGroup.farmersknives.group"))
 				.icon(() -> new ItemStack(ModItems.IRON_KNIFE.get()))
 				.build());
 


### PR DESCRIPTION
changed Text.literal to Text.translatable
that will display the proper item group name in the creative inventory